### PR TITLE
[CI] Allow providing values.ci.yaml, publish charts via release

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -133,7 +133,7 @@ jobs:
             if [ "$(printf '%s\n' "$old_version" "$new_version" | sort -V | head -n1)" = "$old_version" ] && [ "$old_version" != "$new_version" ]; then
               echo "✅ Version bump: $old_version → $new_version"
             else
-              echo "❌ New version ($new_version) is not greater than old version ($old_version)"
+              echo "❌ Version bump required: New version ($new_version) is not greater than old version ($old_version)"
               exit 1
             fi
           }
@@ -177,7 +177,7 @@ jobs:
           readme_needs_update=false
           if ! diff -q "$chart/README.md.original" "$chart/README.md" >/dev/null 2>&1; then
             readme_needs_update=true
-            echo "📝 README.md has changes after generation"
+            echo "❌ README.md for $chart needs to be updated due to changes in values.yaml"
           fi
 
           # Check CHANGELOG (advisory only) - exclude documentation-only changes

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -257,10 +257,12 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
-      pull-requests: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.event.repository.name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -303,29 +305,30 @@ jobs:
         id: package
         run: |
           chart=charts/${{ needs.detect-changed-chart.outputs.chart }}
-          name=$(yq '.name' $chart/Chart.yaml)
-          version=$(yq '.version' $chart/Chart.yaml)
+          mkdir -p .cr-release-packages
+          helm package "$chart" --destination .cr-release-packages
 
-          exists=$(yq eval ".entries[\"$name\"][]?.version" .cr-existing-index/index.yaml | grep -Fx "$version" || true)
-
-          if [ -z "$exists" ]; then
-            echo "📦 Packaging new chart version: $name-$version"
-            helm package "$chart" --destination .cr-release-packages
-            echo "packaged=true" >> $GITHUB_OUTPUT
-          else
-            echo "✔️ Chart $name version $version already exists in index.yaml. Skipping package."
-            echo "packaged=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Update index.yaml
-        if: steps.package.outputs.packaged == 'true'
+      - name: Publish Chart as GitHub Release
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          helm repo index .cr-release-packages --url https://openwallet-foundation.github.io/helm-charts/
+          cr upload \
+            --owner "${OWNER}" \
+            --git-repo "${REPO}" \
+            --package-path ".cr-release-packages" \
+            --skip-existing \
+            --generate-release-notes \
+            --release-name-template "{{ .Name }}-{{ .Version }}" \
+            --make-release-latest=false
 
-      - name: Publish to GitHub Pages
-        if: steps.package.outputs.packaged == 'true'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .cr-release-packages
-          publish_branch: gh-pages
+      - name: Rebuild & push index.yaml to gh-pages
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p .cr-index
+          cr index \
+            --owner "${OWNER}" \
+            --git-repo "${REPO}" \
+            --pages-branch "gh-pages" \
+            --pages-index-path "index.yaml" \
+            --push

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -53,9 +53,9 @@ jobs:
             ${{ runner.os }}-deps-
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@v4.3.1
         with:
-          version: v3.18.4
+          version: v3.18.6
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
@@ -247,9 +247,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@v4.3.1
         with:
-          version: v3.18.4
+          version: v3.18.6
 
       - name: Add Helm repos from chart dependencies
         working-directory: ./charts

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -105,7 +105,7 @@ jobs:
           chart="${{ needs.detect-changed-chart.outputs.chart }}"
           file="charts/$chart/values.ci.yaml"
           if [[ -f "$file" ]]; then
-            echo "install_args=-f $file" >> "$GITHUB_OUTPUT"
+            echo "install_args=-f $(printf '%q' "$file")" >> "$GITHUB_OUTPUT"
             echo "Using CI values: $file"
           else
             echo "install_args=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
 
-      - name: Add Helm repos and update dependencies
+      - name: Build Helm Dependencies
         working-directory: ./charts
         run: |
           chart=${{ needs.detect-changed-chart.outputs.chart }}
@@ -70,17 +70,18 @@ jobs:
             if [ -n "$repo" ] && [ "$repo" != "null" ]; then
               name=$(echo "$repo" | sed 's|https\?://||;s|/|_|g;s|[^a-zA-Z0-9_-]||g')
               echo "Adding repo: $name -> $repo"
-              helm repo add "$name" "$repo" || echo "⚠️ Warning: Failed to add repo $repo"
+              helm repo add "$name" "$repo" || {
+                echo "❌ Failed to add repo $repo"
+                exit 1
+              }
             fi
           done
 
-          # Update Helm dependencies
-          if [ -f "$chart/Chart.yaml" ]; then
-            helm dependency update "$chart" || {
-              echo "❌ Failed to update dependencies for $chart"
-              exit 1
-            }
-          fi
+          # Build Helm dependencies
+          helm dependency build "$chart" || {
+            echo "❌ Failed to build dependencies for $chart"
+            exit 1
+          }
 
       - name: Lint changed chart
         run: ct lint --charts "charts/${{ needs.detect-changed-chart.outputs.chart }}" --config .github/ct.yaml
@@ -251,30 +252,33 @@ jobs:
         with:
           version: v3.18.6
 
-      - name: Add Helm repos from chart dependencies
+      - name: Install chart-releaser (cr)
+        run: |
+          curl -sSL -o cr.tar.gz https://github.com/helm/chart-releaser/releases/download/v1.8.1/chart-releaser_1.8.1_linux_amd64.tar.gz
+          tar -xzf cr.tar.gz cr && sudo mv cr /usr/local/bin/cr
+
+      - name: Build Helm Dependencies
         working-directory: ./charts
         run: |
           chart=${{ needs.detect-changed-chart.outputs.chart }}
 
+          # Add Helm repos from chart dependencies
           yq '.dependencies // [] | .[] | .repository' "$chart/Chart.yaml" | sort | uniq | while read repo; do
             if [ -n "$repo" ] && [ "$repo" != "null" ]; then
               name=$(echo "$repo" | sed 's|https\?://||;s|/|_|g;s|[^a-zA-Z0-9_-]||g')
               echo "Adding repo: $name -> $repo"
-              helm repo add "$name" "$repo" || echo "Warning: Failed to add repo $repo"
+              helm repo add "$name" "$repo" || {
+                echo "❌ Failed to add repo $repo"
+                exit 1
+              }
             fi
           done
 
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
-
-      - name: Prepare release directories and index
-        run: |
-          mkdir -p .cr-release-packages
-          mkdir -p .cr-existing-index
-
-          # Clone existing index.yaml from gh-pages (if any)
-          git fetch origin gh-pages
-          git show origin/gh-pages:index.yaml > .cr-existing-index/index.yaml || echo "apiVersion: v1\nentries: {}\ngenerated: $(date -u +%Y-%m-%dT%H:%M:%SZ)" > .cr-existing-index/index.yaml
+          # Build Helm dependencies
+          helm dependency build "$chart" || {
+            echo "❌ Failed to build dependencies for $chart"
+            exit 1
+          }
 
       - name: Package chart if new version
         id: package

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -98,8 +98,27 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1
 
+      - name: Detect CI values file
+        id: ci_values
+        shell: bash
+        run: |
+          chart="${{ needs.detect-changed-chart.outputs.chart }}"
+          file="charts/$chart/values.ci.yaml"
+          if [[ -f "$file" ]]; then
+            echo "install_args=-f $file" >> "$GITHUB_OUTPUT"
+            echo "Using CI values: $file"
+          else
+            echo "install_args=" >> "$GITHUB_OUTPUT"
+            echo "No CI values file found"
+          fi
+
       - name: Test install changed chart
-        run: ct install --charts "charts/${{ needs.detect-changed-chart.outputs.chart }}" --config .github/ct.yaml
+        run: |
+          extra="${{ steps.ci_values.outputs.install_args }}"
+          ct install \
+            --charts "charts/${{ needs.detect-changed-chart.outputs.chart }}" \
+            --config .github/ct.yaml \
+            --helm-extra-args "$extra"
 
       - name: Check version and appVersion bump
         working-directory: ./charts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,15 @@ To maintain clarity, consistency, and automation reliability, please follow thes
 
 - **Documentation:**
   - Update the chart's `README.md` to reflect any changes.
-    - Use [`@bitnami/readme-generator-for-helm`](https://github.com/bitnami/readme-generator-for-helm) to keep documentation consistent.
+    - Use [`@bitnami/readme-generator-for-helm`](https://github.com/bitnami/readme-generator-for-helm) to keep documentation consistent. Run `npx @bitnami/readme-generator-for-helm --readme charts/<CHART>/README.md --values charts/<CHART>/values.yaml` after modifying `values.yaml` with `@param` annotations.
+    - **Note:** CI will fail the PR if `README.md` requires updates due to `values.yaml` changes.
   - Update the chart's `CHANGELOG.md` with a description of the changes.
-    - Use [`conventional-changelog-cli`](https://github.com/conventional-changelog/conventional-changelog) to generate changelogs.
+    - Use [`conventional-changelog-cli`](https://github.com/conventional-changelog/conventional-changelog) to generate changelogs. Run `npx conventional-changelog -p conventionalcommits -i charts/<CHART>/CHANGELOG.md -s` for significant changes (e.g., features, bug fixes).
 
 ## CI/CD and Automation
 
 - All charts are automatically linted and tested on pull requests.
 - On merge to `main`, any changed charts are automatically published to GitHub Pages.
+- **CI override values**: To make KIND-safe CI installs pass without changing chart defaults, you may add an optional `values.ci.yaml` in the chart directory. This file is only used by CI during test installs and should be excluded from packaging via `.helmignore`.
 
 By adhering to these rules, you help ensure a smooth, automated release process and make reviewing PRs easier for maintainers. Thank you!


### PR DESCRIPTION
This PR refactors the ci-cd workflow with new features and fixes.

- Add step to check for `values.ci.yaml` and forward it to `ct install command`
- Refactor `publish` job to publish helm charts via GitHub release
- Update Helm version
- Update documentation

Note:
The `gh-pages` branch will need to be cleaned up:
- Delete existing helm package
- Update index.yaml, remove existing acapy item.
- Optional: _Older chart version could be published manually, prior to new PRs, which will be added to index.yaml_
