### PR TITLE
[acapy] Fix networkpolicy ingress rendering

### DIFF
--- a/charts/acapy/CHANGELOG.md
+++ b/charts/acapy/CHANGELOG.md
@@ -1,3 +1,8 @@
+##  (2025-08-26)
+
+### Bug Fixes
+
+* correct network policy rendering ([052095b](https://github.com/i5okie/owf-helm-charts/commit/052095b025f90bd5a675e9b414b4e50e9b61f582))
 ##  (2025-08-22)
 
 ### Bug Fixes

--- a/charts/acapy/Chart.yaml
+++ b/charts/acapy/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     name: i5okie
     url: https://github.com/i5okie
 
-version: 0.1.6
+version: 0.1.7
 appVersion: "1.3.1"
 
 dependencies:

--- a/charts/acapy/templates/networkpolicy.yaml
+++ b/charts/acapy/templates/networkpolicy.yaml
@@ -32,7 +32,14 @@ spec:
     {{- end }}
   ingress:
     - ports:
-        - port: {{ .Values.containerPorts }}
+        - port: {{ .Values.service.ports.http | default 8021 }}
+          protocol: TCP
+        - port: {{ .Values.service.ports.admin | default 8022 }}
+          protocol: TCP
+        {{- if .Values.websockets.enabled }}
+        - port: {{ .Values.service.ports.ws | default 8023 }}
+          protocol: TCP
+        {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:


### PR DESCRIPTION
This PR fixes networkpolicy incorrectly rendering a non-existent `containerPorts` value.
- fix networkpolicy to render http, admin, and ws ports
- bump chart version