### PR TITLE
[acapy] fix hostname rendering

### DIFF
--- a/charts/acapy/CHANGELOG.md
+++ b/charts/acapy/CHANGELOG.md
@@ -1,3 +1,22 @@
+##  (2025-09-05)
+
+### Features
+
+* render the ingress hostname as template, to allow other charts to specify templated hostnames. ([77cd136](https://github.com/i5okie/owf-helm-charts/commit/77cd13646fb7dec9dcf383efd1432fb6a8db5212))
+* set plugin-config path if plugin-config is provided ([ede863c](https://github.com/i5okie/owf-helm-charts/commit/ede863cb3d9fed8ef95f95f0e74827094f0984c1))
+
+### Bug Fixes
+
+* replace missing plugin-config path ([f8c1587](https://github.com/i5okie/owf-helm-charts/commit/f8c15870f9717bcc40702ef434eeb159b2bd7c90))
+##  (2025-08-28)
+
+### Features
+
+* set plugin-config path if plugin-config is provided ([ede863c](https://github.com/i5okie/owf-helm-charts/commit/ede863cb3d9fed8ef95f95f0e74827094f0984c1))
+
+### Bug Fixes
+
+* replace missing plugin-config path ([f8c1587](https://github.com/i5okie/owf-helm-charts/commit/f8c15870f9717bcc40702ef434eeb159b2bd7c90))
 ##  (2025-08-27)
 
 ### Features

--- a/charts/acapy/Chart.yaml
+++ b/charts/acapy/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     name: i5okie
     url: https://github.com/i5okie
 
-version: 0.1.8
+version: 0.1.9
 appVersion: "1.3.1"
 
 dependencies:

--- a/charts/acapy/Chart.yaml
+++ b/charts/acapy/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     name: i5okie
     url: https://github.com/i5okie
 
-version: 0.1.9
+version: 0.2.0
 appVersion: "1.3.1"
 
 dependencies:

--- a/charts/acapy/README.md
+++ b/charts/acapy/README.md
@@ -1,6 +1,6 @@
 # AcaPy
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart to deploy A Cloud Agent - Python.
 

--- a/charts/acapy/README.md
+++ b/charts/acapy/README.md
@@ -1,6 +1,6 @@
 # AcaPy
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart to deploy A Cloud Agent - Python.
 

--- a/charts/acapy/templates/_helpers.tpl
+++ b/charts/acapy/templates/_helpers.tpl
@@ -5,7 +5,7 @@ generate hosts if not overriden
 {{- if and .Values.agentUrl (not .Values.ingress.agent.enabled) }}
     {{ .Values.agentUrl }}
 {{- else -}}
-    {{ .Values.ingress.agent.hostname }}
+    {{ tpl .Values.ingress.agent.hostname . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/acapy/templates/deployment.yaml
+++ b/charts/acapy/templates/deployment.yaml
@@ -84,7 +84,9 @@ spec:
             - >-
               aca-py start
               --arg-file '/home/aries/argfile.yml'
+              {{- if index .Values "plugin-config.yml" }}
               --plugin-config '/home/aries/plugin-config.yml'
+              {{- end }}
               {{- if .Values.extraArgs }}
               {{ .Values.extraArgs | join " " }}
               {{- end }}

--- a/charts/acapy/templates/deployment.yaml
+++ b/charts/acapy/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
             - >-
               aca-py start
               --arg-file '/home/aries/argfile.yml'
+              --plugin-config '/home/aries/plugin-config.yml'
               {{- if .Values.extraArgs }}
               {{ .Values.extraArgs | join " " }}
               {{- end }}


### PR DESCRIPTION
This PR addresses the issue with the `endpoint` not being rendered correctly when specifying a templated value.