### PR TITLE
[acapy] Secret handling fixes, docs, and network policy hardening

### DIFF
--- a/charts/acapy/CHANGELOG.md
+++ b/charts/acapy/CHANGELOG.md
@@ -1,3 +1,22 @@
+##  (2025-09-05)
+
+### Features
+
+* render the ingress hostname as template, to allow other charts to specify templated hostnames. ([77cd136](https://github.com/i5okie/owf-helm-charts/commit/77cd13646fb7dec9dcf383efd1432fb6a8db5212))
+* set plugin-config path if plugin-config is provided ([ede863c](https://github.com/i5okie/owf-helm-charts/commit/ede863cb3d9fed8ef95f95f0e74827094f0984c1))
+
+### Bug Fixes
+
+* replace missing plugin-config path ([f8c1587](https://github.com/i5okie/owf-helm-charts/commit/f8c15870f9717bcc40702ef434eeb159b2bd7c90))
+##  (2025-08-28)
+
+### Features
+
+* set plugin-config path if plugin-config is provided ([ede863c](https://github.com/i5okie/owf-helm-charts/commit/ede863cb3d9fed8ef95f95f0e74827094f0984c1))
+
+### Bug Fixes
+
+* replace missing plugin-config path ([f8c1587](https://github.com/i5okie/owf-helm-charts/commit/f8c15870f9717bcc40702ef434eeb159b2bd7c90))
 ##  (2025-08-27)
 
 ### Features

--- a/charts/acapy/CHANGELOG.md
+++ b/charts/acapy/CHANGELOG.md
@@ -4,14 +4,6 @@
 
 * add support for existing API and seed secrets, with configurable keys and retention policy ([2e21e3e](https://github.com/i5okie/owf-helm-charts/commit/2e21e3e5491de2f85adccedd7167fb80326b4ba0))
 * render the ingress hostname as template, to allow other charts to specify templated hostnames. ([77cd136](https://github.com/i5okie/owf-helm-charts/commit/77cd13646fb7dec9dcf383efd1432fb6a8db5212))
-* set plugin-config path if plugin-config is provided ([ede863c](https://github.com/i5okie/owf-helm-charts/commit/ede863cb3d9fed8ef95f95f0e74827094f0984c1))
-
-##  (2025-09-05)
-
-### Features
-
-* render the ingress hostname as template, to allow other charts to specify templated hostnames. ([77cd136](https://github.com/i5okie/owf-helm-charts/commit/77cd13646fb7dec9dcf383efd1432fb6a8db5212))
-* set plugin-config path if plugin-config is provided ([ede863c](https://github.com/i5okie/owf-helm-charts/commit/ede863cb3d9fed8ef95f95f0e74827094f0984c1))
 
 ##  (2025-08-28)
 

--- a/charts/acapy/CHANGELOG.md
+++ b/charts/acapy/CHANGELOG.md
@@ -5,6 +5,9 @@
 * add support for existing API and seed secrets, with configurable keys and retention policy ([2e21e3e](https://github.com/i5okie/owf-helm-charts/commit/2e21e3e5491de2f85adccedd7167fb80326b4ba0))
 * render the ingress hostname as template, to allow other charts to specify templated hostnames. ([77cd136](https://github.com/i5okie/owf-helm-charts/commit/77cd13646fb7dec9dcf383efd1432fb6a8db5212))
 
+### Bug Fixes
+
+* revert change to database secret name rendering ([7e1cfbe](https://github.com/i5okie/owf-helm-charts/commit/7e1cfbe49cbc45f4e432429f0ac2a74d18e34701))
 ##  (2025-08-28)
 
 ### Features

--- a/charts/acapy/CHANGELOG.md
+++ b/charts/acapy/CHANGELOG.md
@@ -1,3 +1,11 @@
+##  (2025-09-10)
+
+### Features
+
+* add support for existing API and seed secrets, with configurable keys and retention policy ([2e21e3e](https://github.com/i5okie/owf-helm-charts/commit/2e21e3e5491de2f85adccedd7167fb80326b4ba0))
+* render the ingress hostname as template, to allow other charts to specify templated hostnames. ([77cd136](https://github.com/i5okie/owf-helm-charts/commit/77cd13646fb7dec9dcf383efd1432fb6a8db5212))
+* set plugin-config path if plugin-config is provided ([ede863c](https://github.com/i5okie/owf-helm-charts/commit/ede863cb3d9fed8ef95f95f0e74827094f0984c1))
+
 ##  (2025-09-05)
 
 ### Features
@@ -5,9 +13,6 @@
 * render the ingress hostname as template, to allow other charts to specify templated hostnames. ([77cd136](https://github.com/i5okie/owf-helm-charts/commit/77cd13646fb7dec9dcf383efd1432fb6a8db5212))
 * set plugin-config path if plugin-config is provided ([ede863c](https://github.com/i5okie/owf-helm-charts/commit/ede863cb3d9fed8ef95f95f0e74827094f0984c1))
 
-### Bug Fixes
-
-* replace missing plugin-config path ([f8c1587](https://github.com/i5okie/owf-helm-charts/commit/f8c15870f9717bcc40702ef434eeb159b2bd7c90))
 ##  (2025-08-28)
 
 ### Features

--- a/charts/acapy/Chart.yaml
+++ b/charts/acapy/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     name: i5okie
     url: https://github.com/i5okie
 
-version: 0.1.8
+version: 0.1.9
 appVersion: "1.3.1"
 
 dependencies:

--- a/charts/acapy/Chart.yaml
+++ b/charts/acapy/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     name: i5okie
     url: https://github.com/i5okie
 
-version: 0.1.9
+version: 0.2.0
 appVersion: "1.3.1"
 
 dependencies:

--- a/charts/acapy/Chart.yaml
+++ b/charts/acapy/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     name: i5okie
     url: https://github.com/i5okie
 
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.3.1"
 
 dependencies:

--- a/charts/acapy/README.md
+++ b/charts/acapy/README.md
@@ -1,6 +1,6 @@
 # AcaPy
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart to deploy A Cloud Agent - Python.
 

--- a/charts/acapy/README.md
+++ b/charts/acapy/README.md
@@ -1,6 +1,6 @@
 # AcaPy
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart to deploy A Cloud Agent - Python.
 

--- a/charts/acapy/README.md
+++ b/charts/acapy/README.md
@@ -1,6 +1,6 @@
 # AcaPy
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
 
 A Helm chart to deploy A Cloud Agent - Python.
 
@@ -94,6 +94,32 @@ Note: Secure values of the configuration are passed via equivalent environment v
 | `plugin-config.yml`                               | Plugin configuration file                                                                                                                                                                                                                                                                                                                                                                            | `{}`                                                        |
 | `websockets.enabled`                              | Enable or disable the websocket transport for the agent.                                                                                                                                                                                                                                                                                                                                             | `false`                                                     |
 | `websockets.publicUrl`                            | Explicit public websockets URL. If not set, it will be derived from agentUrl or ingress.publicScheme.                                                                                                                                                                                                                                                                                                | `""`                                                        |
+
+### Secrets
+
+Secrets used by the chart. By default the chart will generate (and retain) the API and seed secrets
+using the getOrGeneratePass helper (random if not already present). In GitOps environments where
+lookups are not possible (e.g. ArgoCD dry‑run), provide existing secrets instead to avoid drift.
+
+API Secret keys expected (unless overridden via secretKeys):
+  adminApiKey   (omitted if argfile.yml.admin-insecure-mode=true)
+  jwt           (multitenant JWT signing secret)
+  walletKey     (primary wallet key / encryption key)
+  webhookapi    (optional key appended to webhook-url if using #APIKEY pattern)
+Seed Secret keys expected:
+  seed          (32 char wallet seed when wallet-local-did=true or deterministic DID needed)
+
+| Name                                   | Description                                                                                              | Value         |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------- |
+| `secrets.api.retainOnUninstall`        | When true, adds helm.sh/resource-policy: keep to generated api secret                                    | `true`        |
+| `secrets.api.existingSecret`           | Name of an existing Secret providing API related keys. If set, the chart will NOT create the api secret. | `""`          |
+| `secrets.api.secretKeys.adminApiKey`   | Key in the API secret holding the admin API key.                                                         | `adminApiKey` |
+| `secrets.api.secretKeys.jwtKey`        | Key in the API secret holding the multitenant JWT signing secret.                                        | `jwt`         |
+| `secrets.api.secretKeys.walletKey`     | Key in the API secret holding the wallet key.                                                            | `walletKey`   |
+| `secrets.api.secretKeys.webhookapiKey` | Key in the API secret holding the webhook API key (used when embedding in webhook-url).                  | `webhookapi`  |
+| `secrets.seed.retainOnUninstall`       | When true, adds helm.sh/resource-policy: keep to generated api secret                                    | `true`        |
+| `secrets.seed.existingSecret`          | Name of an existing Secret providing the wallet seed. If set, the chart will NOT create the seed secret. | `""`          |
+| `secrets.seed.secretKeys.seed`         | Key in the seed secret holding the wallet seed value.                                                    | `seed`        |
 
 ### Wallet Storage configuration
 

--- a/charts/acapy/README.md
+++ b/charts/acapy/README.md
@@ -117,7 +117,7 @@ Seed Secret keys expected:
 | `secrets.api.secretKeys.jwtKey`        | Key in the API secret holding the multitenant JWT signing secret.                                        | `jwt`         |
 | `secrets.api.secretKeys.walletKey`     | Key in the API secret holding the wallet key.                                                            | `walletKey`   |
 | `secrets.api.secretKeys.webhookapiKey` | Key in the API secret holding the webhook API key (used when embedding in webhook-url).                  | `webhookapi`  |
-| `secrets.seed.retainOnUninstall`       | When true, adds helm.sh/resource-policy: keep to generated api secret                                    | `true`        |
+| `secrets.seed.retainOnUninstall`       | When true, adds helm.sh/resource-policy: keep to generated seed secret                                   | `true`        |
 | `secrets.seed.existingSecret`          | Name of an existing Secret providing the wallet seed. If set, the chart will NOT create the seed secret. | `""`          |
 | `secrets.seed.secretKeys.seed`         | Key in the seed secret holding the wallet seed value.                                                    | `seed`        |
 

--- a/charts/acapy/templates/_helpers.tpl
+++ b/charts/acapy/templates/_helpers.tpl
@@ -5,7 +5,7 @@ generate hosts if not overriden
 {{- if and .Values.agentUrl (not .Values.ingress.agent.enabled) }}
     {{ .Values.agentUrl }}
 {{- else -}}
-    {{ .Values.ingress.agent.hostname }}
+    {{ tpl .Values.ingress.agent.hostname . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/acapy/templates/_helpers.tpl
+++ b/charts/acapy/templates/_helpers.tpl
@@ -118,7 +118,7 @@ Return the Secret that holds the Postgres credentials.
 {{- end -}}
 
 {{/*
-Return the Secret name or API secret
+Return the Secret name for API secret
 */}}
 {{- define "acapy.api.secretName" -}}
 {{- if .Values.secrets.api.existingSecret -}}
@@ -129,7 +129,7 @@ Return the Secret name or API secret
 {{- end -}}
 
 {{/*
-Return the Secret name or seed secret
+Return the Secret name for seed secret
 */}}
 {{- define "acapy.seed.secretName" -}}
 {{- if .Values.secrets.seed.existingSecret -}}

--- a/charts/acapy/templates/_helpers.tpl
+++ b/charts/acapy/templates/_helpers.tpl
@@ -118,6 +118,28 @@ Return the Secret that holds the Postgres credentials.
 {{- end -}}
 
 {{/*
+Return the Secret name or API secret
+*/}}
+{{- define "acapy.api.secretName" -}}
+{{- if .Values.secrets.api.existingSecret -}}
+{{- tpl .Values.secrets.api.existingSecret . }}
+{{- else -}}
+{{- printf "%s-api" (include "common.names.fullname" .) }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Secret name or seed secret
+*/}}
+{{- define "acapy.seed.secretName" -}}
+{{- if .Values.secrets.seed.existingSecret -}}
+{{- tpl .Values.secrets.seed.existingSecret . }}
+{{- else -}}
+{{- printf "%s-seed" (include "common.names.fullname" .) }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Generate ACA-Py wallet storage config
 */}}
 {{- define "acapy.walletStorageConfig" -}}

--- a/charts/acapy/templates/api-secret.yaml
+++ b/charts/acapy/templates/api-secret.yaml
@@ -1,4 +1,5 @@
-{{ $secretName := printf "%s-api" (include "common.names.fullname" .) }}
+{{- if not .Values.secrets.api.existingSecret }}
+{{ $secretName := include "acapy.api.secretName" . }}
 {{ $adminApiKey := include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" $secretName "Key" "adminApiKey" "Length" 32) }}
 {{ $jwt := include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" $secretName "Key" "jwt" "Length" 32) }}
 {{ $walletKey := include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" $secretName "Key" "walletKey" "Length" 32) }}
@@ -7,7 +8,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   annotations:
+    {{- if .Values.secrets.api.retainOnUninstall }}
     helm.sh/resource-policy: keep
+    {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
@@ -23,3 +26,4 @@ data:
   adminApiKey: {{ $adminApiKey }}
   {{- end }}
   walletKey: {{ $walletKey }}
+{{- end }}

--- a/charts/acapy/templates/deployment.yaml
+++ b/charts/acapy/templates/deployment.yaml
@@ -1,4 +1,6 @@
-{{ $apiSecretName := printf "%s-api" (include "common.names.fullname" .) }}
+{{ $apiSecretName := include "acapy.api.secretName" . }}
+{{ $seedSecretName := include "acapy.seed.secretName" . }}
+{{ $databaseSecretName := tpl "acapy.database.secretName" . }}
 {{ $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
@@ -95,33 +97,33 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $apiSecretName }}
-                  key: adminApiKey
+                  key: {{ .Values.secrets.api.secretKeys.adminApiKey | default "adminApiKey" }}
                   optional: true
             - name: ACAPY_WALLET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $apiSecretName }}
-                  key: walletKey
+                  key: {{ .Values.secrets.api.secretKeys.walletKey | default "walletKey" }}
             - name: ACAPY_WALLET_SEED
               valueFrom:
                 secretKeyRef:
-                  name: {{ printf "%s-seed" (include "common.names.fullname" .) }}
-                  key: seed
+                  name: {{ $seedSecretName }}
+                  key: {{ default "seed" .Values.secrets.seed.secretKeys.seed }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "acapy.database.secretName" . }}
+                  name: {{ $databaseSecretName }}
                   key: {{ .Values.walletStorageCredentials.secretKeys.userPasswordKey }}
             - name: POSTGRES_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "acapy.database.secretName" . }}
+                  name: {{ $databaseSecretName }}
                   key: {{ .Values.walletStorageCredentials.secretKeys.adminPasswordKey }}
             - name: ACAPY_MULTITENANT_JWT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ $apiSecretName }}
-                  key: jwt
+                  key: {{ .Values.secrets.api.secretKeys.jwtKey | default "jwt" }}
             - name: ACAPY_WALLET_STORAGE_CREDS
               value: {{ include "acapy.walletStorageCredentials" . }}
             {{- if .Values.extraEnvVars }}

--- a/charts/acapy/templates/deployment.yaml
+++ b/charts/acapy/templates/deployment.yaml
@@ -84,7 +84,9 @@ spec:
             - >-
               aca-py start
               --arg-file '/home/aries/argfile.yml'
+              {{- if index .Values "plugin-config.yml" }}
               --plugin-config '/home/aries/plugin-config.yml'
+              {{- end }}
               {{- if .Values.extraArgs }}
               {{ .Values.extraArgs | join " " }}
               {{- end }}

--- a/charts/acapy/templates/deployment.yaml
+++ b/charts/acapy/templates/deployment.yaml
@@ -1,6 +1,5 @@
 {{ $apiSecretName := include "acapy.api.secretName" . }}
 {{ $seedSecretName := include "acapy.seed.secretName" . }}
-{{ $databaseSecretName := tpl "acapy.database.secretName" . }}
 {{ $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
@@ -112,12 +111,12 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $databaseSecretName }}
+                  name: {{ template "acapy.database.secretName" . }}
                   key: {{ .Values.walletStorageCredentials.secretKeys.userPasswordKey }}
             - name: POSTGRES_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $databaseSecretName }}
+                  name: {{ template "acapy.database.secretName" . }}
                   key: {{ .Values.walletStorageCredentials.secretKeys.adminPasswordKey }}
             - name: ACAPY_MULTITENANT_JWT_SECRET
               valueFrom:

--- a/charts/acapy/templates/deployment.yaml
+++ b/charts/acapy/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $seedSecretName }}
-                  key: {{ default "seed" .Values.secrets.seed.secretKeys.seed }}
+                  key: {{ .Values.secrets.seed.secretKeys.seed | default "seed" }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/acapy/templates/deployment.yaml
+++ b/charts/acapy/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
             - >-
               aca-py start
               --arg-file '/home/aries/argfile.yml'
+              --plugin-config '/home/aries/plugin-config.yml'
               {{- if .Values.extraArgs }}
               {{ .Values.extraArgs | join " " }}
               {{- end }}

--- a/charts/acapy/templates/seed-secret.yaml
+++ b/charts/acapy/templates/seed-secret.yaml
@@ -1,8 +1,9 @@
 {{- if not .Values.secrets.seed.existingSecret }}
+{{ $secretName := include "acapy.seed.secretName" . }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-seed" (include "common.names.fullname" .) }}
+  name: {{ $secretName }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: agent
   annotations:
@@ -15,5 +16,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  seed: {{ include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" (printf "%s-seed" (include "common.names.fullname" .)) "Key" "seed" "Length" 32) }}
+  seed: {{ include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" ($secretName) "Key" "seed" "Length" 32) }}
 {{- end }}

--- a/charts/acapy/templates/seed-secret.yaml
+++ b/charts/acapy/templates/seed-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secrets.seed.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,7 +6,9 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: agent
   annotations:
+    {{- if .Values.secrets.seed.retainOnUninstall }}
     helm.sh/resource-policy: keep
+    {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
@@ -13,3 +16,4 @@ metadata:
 type: Opaque
 data:
   seed: {{ include "getOrGeneratePass" (dict "Namespace" .Release.Namespace "Kind" "Secret" "Name" (printf "%s-seed" (include "common.names.fullname" .)) "Key" "seed" "Length" 32) }}
+{{- end }}

--- a/charts/acapy/values.yaml
+++ b/charts/acapy/values.yaml
@@ -228,7 +228,7 @@ websockets:
 ## @param secrets.api.secretKeys.jwtKey Key in the API secret holding the multitenant JWT signing secret.
 ## @param secrets.api.secretKeys.walletKey Key in the API secret holding the wallet key.
 ## @param secrets.api.secretKeys.webhookapiKey Key in the API secret holding the webhook API key (used when embedding in webhook-url).
-## @param secrets.seed.retainOnUninstall When true, adds helm.sh/resource-policy: keep to generated api secret
+## @param secrets.seed.retainOnUninstall When true, adds helm.sh/resource-policy: keep to generated seed secret
 ## @param secrets.seed.existingSecret Name of an existing Secret providing the wallet seed. If set, the chart will NOT create the seed secret.
 ## @param secrets.seed.secretKeys.seed Key in the seed secret holding the wallet seed value.
 secrets:

--- a/charts/acapy/values.yaml
+++ b/charts/acapy/values.yaml
@@ -75,6 +75,7 @@ image:
   registry: ghcr.io
   repository: openwallet-foundation/acapy-agent
   tag: py3.12-1.3.1
+  ## For production, prefer setting image.digest to an immutable sha256:... to guarantee supply chain integrity over mutable tags.
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -205,6 +206,45 @@ websockets:
   ## @param websockets.publicUrl Explicit public websockets URL. If not set, it will be derived from agentUrl or ingress.publicScheme.
   ##
   publicUrl: ""
+
+## @section Secrets
+## @descriptionStart
+## Secrets used by the chart. By default the chart will generate (and retain) the API and seed secrets
+## using the getOrGeneratePass helper (random if not already present). In GitOps environments where
+## lookups are not possible (e.g. ArgoCD dry‑run), provide existing secrets instead to avoid drift.
+##
+## API Secret keys expected (unless overridden via secretKeys):
+##   adminApiKey   (omitted if argfile.yml.admin-insecure-mode=true)
+##   jwt           (multitenant JWT signing secret)
+##   walletKey     (primary wallet key / encryption key)
+##   webhookapi    (optional key appended to webhook-url if using #APIKEY pattern)
+## Seed Secret keys expected:
+##   seed          (32 char wallet seed when wallet-local-did=true or deterministic DID needed)
+## @descriptionEnd
+##
+## @param secrets.api.retainOnUninstall When true, adds helm.sh/resource-policy: keep to generated api secret
+## @param secrets.api.existingSecret Name of an existing Secret providing API related keys. If set, the chart will NOT create the api secret.
+## @param secrets.api.secretKeys.adminApiKey Key in the API secret holding the admin API key.
+## @param secrets.api.secretKeys.jwtKey Key in the API secret holding the multitenant JWT signing secret.
+## @param secrets.api.secretKeys.walletKey Key in the API secret holding the wallet key.
+## @param secrets.api.secretKeys.webhookapiKey Key in the API secret holding the webhook API key (used when embedding in webhook-url).
+## @param secrets.seed.retainOnUninstall When true, adds helm.sh/resource-policy: keep to generated api secret
+## @param secrets.seed.existingSecret Name of an existing Secret providing the wallet seed. If set, the chart will NOT create the seed secret.
+## @param secrets.seed.secretKeys.seed Key in the seed secret holding the wallet seed value.
+secrets:
+  api:
+    retainOnUninstall: true
+    existingSecret: ""
+    secretKeys:
+      adminApiKey: adminApiKey
+      jwtKey: jwt
+      walletKey: walletKey
+      webhookapiKey: webhookapi
+  seed:
+    retainOnUninstall: true
+    existingSecret: ""
+    secretKeys:
+      seed: seed
 
 ## @section Wallet Storage configuration
 ## @descriptionStart


### PR DESCRIPTION
- Adds ability to specify existing secrets for api and seed secrets, with customizable secret key names
- Adds per-secret retainOnUninstall toggles with conditional keep annotations.
- Aligns API secret key names (jwt, webhookapi) between templates and deployment to prevent drift.
- Documents secrets usage (including existingSecret pattern) and adds image digest guidance in values.yaml.
- Minor security hardening: predictable retention behavior, explicit guidance for digest pinning.
- Bump version to 0.2.1, update Readme, update Changelog