### PR TITLE
fix(pre-commit): fix .yamllint path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,4 +29,4 @@ repos:
     hooks:
       - id: yamllint
         files: ^charts/.*/values.*\.yaml$|^charts/.*/Chart\.yaml$
-        args: [--strict, -c=.yamllint.yaml]
+        args: [--strict, -c=.yamllint]


### PR DESCRIPTION
`.pre-commit-config.yaml` was incorrectly referencing the yamllint config at `.yamllint.yaml`
This PR fixes this to `.yamllint`, which is also used by chart testing.