### PR TITLE
feat(ci): for first release, use chart.yaml version as-is.

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -173,8 +173,14 @@ jobs:
               continue
             fi
 
-            next_version="$(hack/release/next_version.sh "$current_version" "" "$final_bump")"
-            echo "Next version: ${next_version} (${final_bump} bump)"
+            # For first release (no prior tag), use Chart.yaml version as-is
+            if [ -z "$last_tag" ]; then
+              next_version="$current_version"
+              echo "Next version: ${next_version} (first release, using Chart.yaml version)"
+            else
+              next_version="$(hack/release/next_version.sh "$current_version" "" "$final_bump")"
+              echo "Next version: ${next_version} (${final_bump} bump)"
+            fi
 
             # Create/switch to release branch
             branch="release/${chart}-v${next_version}"


### PR DESCRIPTION
## Summary

Currently, the `release-pr` workflow generates a release PR from detected changes and bumps the version regardless of whether it’s a new chart or not. 

This PR fixes the logic and checks if previous tags exist for the Chart. If no previous tags exist, the workflow will use the version from Chart.yaml as-is without bumping.