### PR TITLE
feat(ci): Remove unnecessary line length warning in .yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -24,11 +24,6 @@ rules:
     spaces: 2
     indent-sequences: true
 
-  # Relaxed for long descriptions in values.yaml
-  line-length:
-    max: 120
-    level: warning
-
   # Allow flexible comment formatting
   comments-indentation: disable
 


### PR DESCRIPTION
## Summary

Yaml linting in CI has been giving us warnings about lines longer than 120 characters in Values files.
This PR removes this setting from the .yamllint file, as it is not necessary.
