### PR TITLE
fix(ci): disable line length checking in .yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -31,3 +31,6 @@ rules:
   empty-values:
     forbid-in-block-mappings: false
     forbid-in-flow-mappings: false
+
+  # Disable line length warnings
+  line-length: disable


### PR DESCRIPTION
## Summary

Removing the line-length setting in .yamllint resulted in failing workflows due to line length errors.
This PR disables line-length checking all together.