### PR TITLE
fix(ci): respect bump labels and fix PR search pattern

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -140,20 +140,20 @@ jobs:
             override=""
             skip="false"
             # Query GitHub API for existing release PR (filter by prefix since --head doesn't support wildcards)
-            existing_pr=$(gh pr list --state open --json number,labels,headRefName | jq -r --arg prefix "release/${chart}-" 'map(select(.headRefName | startswith($prefix))) | .[0] // {}' || echo "{}")
-            if [ "$existing_pr" != "{}" ] && [ "$existing_pr" != "null" ]; then
+            existing_pr=$(gh pr list --state open --json number,labels,headRefName | jq -r --arg prefix "release/${chart}-" 'map(select(.headRefName | startswith($prefix))) | .[0] // empty')
+            if [ -n "$existing_pr" ]; then
               labels=$(echo "$existing_pr" | jq -r '.labels[].name')
               if echo "$labels" | grep -q "skip-release"; then
                 echo "::notice::Found 'skip-release' label, skipping ${chart}"
                 skip="true"
               elif echo "$labels" | grep -q "bump:major"; then
                 override="major"
-                echo "::notice::Label override detected: ${override}"
               elif echo "$labels" | grep -q "bump:minor"; then
                 override="minor"
-                echo "::notice::Label override detected: ${override}"
               elif echo "$labels" | grep -q "bump:patch"; then
                 override="patch"
+              fi
+              if [ -n "$override" ]; then
                 echo "::notice::Label override detected: ${override}"
               fi
             fi


### PR DESCRIPTION
## Summary

Release PR workflow ignores bump labels. This PR fixes the pattern matching, replacing it with jq filtering.
Also, this check is now executed on every workflow run.