### PR TITLE
feat: Update mediator version to 0c5db35

### DIFF
--- a/charts/didcomm-mediator-credo/values.yaml
+++ b/charts/didcomm-mediator-credo/values.yaml
@@ -14,7 +14,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "ba7c1eb"
+  tag: "0c5db35"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 ## @param imagePullSecrets [array]


### PR DESCRIPTION
I'm hoping this should be the last image update until the 0.6.x credo version of the mediator which will be a larger update. This update just has a small bug fix for the multi-firebase feature when mobile agents don't send a device token.

--> https://github.com/openwallet-foundation/didcomm-mediator-credo/commit/ad956a1d47f8056205df0c6f36fb68d86efc4d74