### PR TITLE
fix(vc-authn-oidc): cronjob selector labels

### DIFF
--- a/charts/vc-authn-oidc/templates/_helpers.tpl
+++ b/charts/vc-authn-oidc/templates/_helpers.tpl
@@ -65,6 +65,22 @@ component: controller
 {{- end }}
 
 {{/*
+Selector cleanup labels
+*/}}
+{{- define "vc-authn-oidc.cleanup.selectorLabels" -}}
+{{ include "common.selectorLabels" . }}
+component: cleanup
+{{- end }}
+
+{{/*
+Cleanup labels
+*/}}
+{{- define "vc-authn-oidc.cleanup.labels" -}}
+{{ include "common.labels" . }}
+{{ include "vc-authn-oidc.cleanup.selectorLabels" . }}
+{{- end }}
+
+{{/*
 Selector redis labels
 */}}
 {{- define "vc-authn-oidc.redis.selectorLabels" -}}

--- a/charts/vc-authn-oidc/templates/cronjob.yaml
+++ b/charts/vc-authn-oidc/templates/cronjob.yaml
@@ -4,8 +4,7 @@ kind: CronJob
 metadata:
   name: {{ include "global.fullname" . }}-cleanup
   labels:
-    {{- include "vc-authn-oidc.labels" . | nindent 4 }}
-    component: cleanup
+    {{- include "vc-authn-oidc.cleanup.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.cleanup.cronjob.schedule | quote }}
   concurrencyPolicy: Forbid
@@ -16,8 +15,7 @@ spec:
       template:
         metadata:
           labels:
-            {{- include "vc-authn-oidc.selectorLabels" . | nindent 12 }}
-            component: cleanup
+            {{- include "vc-authn-oidc.cleanup.selectorLabels" . | nindent 12 }}
         spec:
           restartPolicy: OnFailure
           containers:

--- a/charts/vc-authn-oidc/templates/networkpolicy-cronjob.yaml
+++ b/charts/vc-authn-oidc/templates/networkpolicy-cronjob.yaml
@@ -6,13 +6,12 @@ metadata:
   labels:
     {{- include "vc-authn-oidc.labels" . | nindent 4 }}
 spec:
-  # Allow traffic from the agent to the controller
+  # Allow traffic from the cleanup cronjob to the controller
   ingress:
     - from:
         - podSelector:
             matchLabels:
-              {{ include "vc-authn-oidc.selectorLabels" . | nindent 14 }}
-              component: cleanup
+              {{- include "vc-authn-oidc.cleanup.selectorLabels" . | nindent 14 }}
       ports:
         - protocol: TCP
           port: {{ .Values.service.port }}


### PR DESCRIPTION
## Summary

This PR fixes the cleanup cronjob and controller deployment selector labels.
- Added new helper templates `vc-authn-oidc.cleanup.selectorLabels` and `vc-authn-oidc.cleanup.labels` to properly define cleanup component labels
- Updated `cronjob.yaml` to use the new cleanup-specific label helpers instead of mixing controller and cleanup labels
- Updated `networkpolicy-cronjob.yaml` to use cleanup-specific selector labels for consistent pod matching