### PR TITLE
fix(cicd): skip oci urls during helm repo add

### DIFF
--- a/.github/workflows/pr-lint-test.yaml
+++ b/.github/workflows/pr-lint-test.yaml
@@ -72,6 +72,12 @@ jobs:
           repos_added=0
           for repo in $repos; do
             if [ -n "$repo" ] && [ "$repo" != "null" ]; then
+              # Skip OCI registries - they don't use helm repo add
+              if [[ "$repo" == oci://* ]]; then
+                echo "Skipping OCI registry (handled by helm dependency build): $repo"
+                continue
+              fi
+
               # Generate deterministic name from URL hash (first 8 chars of sha256)
               repo_hash=$(echo -n "$repo" | sha256sum | cut -c1-8)
               repo_name="repo-${repo_hash}"

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -86,6 +86,12 @@ jobs:
           repos_added=0
           for repo in $repos; do
             if [ -n "$repo" ] && [ "$repo" != "null" ]; then
+              # Skip OCI registries - they don't use helm repo add
+              if [[ "$repo" == oci://* ]]; then
+                echo "Skipping OCI registry (handled by helm dependency build): $repo"
+                continue
+              fi
+
               # Generate deterministic name from URL hash (first 8 chars of sha256)
               repo_hash=$(echo -n "$repo" | sha256sum | cut -c1-8)
               repo_name="repo-${repo_hash}"

--- a/hack/chart/local-test.sh
+++ b/hack/chart/local-test.sh
@@ -29,6 +29,11 @@ log_info "Building chart dependencies for ${CHART_NAME}"
   repo_list=$(yq '.dependencies // [] | .[] | .repository' "${CHART_NAME}/Chart.yaml" | sed '/^null$/d' | sort -u)
   mapfile -t repos <<< "${repo_list}"
   for repo in "${repos[@]:-}"; do
+    # Skip OCI registries - they don't use helm repo add
+    if [[ "${repo}" == oci://* ]]; then
+      echo "  - skipping OCI registry: ${repo}"
+      continue
+    fi
     name="$(sed -E 's|https?://||;s|/|_|g;s|[^a-zA-Z0-9_-]||g' <<< "${repo}")"
     echo "  - helm repo add ${name} ${repo}"
     helm repo add "${name}" "${repo}" > /dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

`helm repo add` does not support repos wth `oci://` url. This is handled by `helm dependency update|build` command.

- Update workflows
- Update local test script