### PR TITLE
feat(cicd): Improve change discovery, commit classification, and add force-bump

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      force_bump:
+        description: "Force a patch release even if no releasable commits found (requires chart input)"
+        required: false
+        default: false
+        type: boolean
   schedule:
     # Daily at 2:00 AM UTC
     - cron: '0 2 * * *'
@@ -24,39 +29,25 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHART_INPUT: ${{ github.event.inputs.chart || '' }}
+      FORCE_BUMP: ${{ github.event.inputs.force_bump || 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Check if release commit
-        id: check-release-commit
-        run: |
-          last_commit_msg=$(git log -1 --pretty=%B)
-          if echo "$last_commit_msg" | grep -q "^chore(.*): prepare release"; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Last commit is a release preparation commit, skipping workflow"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Load version pins
-        if: steps.check-release-commit.outputs.skip != 'true'
         uses: ./.github/actions/load-pins
 
       - name: Install generators (pinned)
-        if: steps.check-release-commit.outputs.skip != 'true'
         uses: ./.github/actions/install-generators
 
       - name: Configure git
-        if: steps.check-release-commit.outputs.skip != 'true'
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
 
       - name: Discover charts needing release
-        if: steps.check-release-commit.outputs.skip != 'true'
         id: discover
         shell: bash
         run: |
@@ -79,6 +70,15 @@ jobs:
             [ -z "$chart" ] && continue
             echo "::group::Checking ${chart}"
 
+            # Skip if the last commit to THIS chart is a release prep commit
+            # This prevents re-triggering immediately after a release PR is merged
+            last_commit_for_chart=$(git log -1 --pretty=%s -- "charts/${chart}/")
+            if echo "$last_commit_for_chart" | grep -q "^chore(${chart}): prepare release"; then
+              echo "⏭️  ${chart}: last commit is a release prep, skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
             last_tag="$(git tag --list "${chart}-*" | sort -V | tail -1 || true)"
             echo "Last tag for ${chart}: ${last_tag:-none}"
 
@@ -89,6 +89,12 @@ jobs:
               continue
             }
             eval "$classify_output"
+
+            # Check if force_bump should override BUMP_LEVEL=none
+            if [ "${BUMP_LEVEL}" = "none" ] && [ "${FORCE_BUMP}" = "true" ] && [ -n "${CHART_INPUT}" ]; then
+              echo "⚠️  ${chart}: forcing patch bump (no releasable commits, but force_bump=true)"
+              BUMP_LEVEL="patch"
+            fi
 
             if [ "${BUMP_LEVEL}" != "none" ] && [ -n "${BUMP_LEVEL}" ]; then
               echo "✅ ${chart} needs ${BUMP_LEVEL} bump"
@@ -109,11 +115,13 @@ jobs:
           fi
 
       - name: Process release PRs
-        if: steps.check-release-commit.outputs.skip != 'true' && steps.discover.outputs.charts_json != '[]'
+        if: steps.discover.outputs.charts_json != '[]'
         shell: bash
         env:
           CHARTS_JSON: ${{ steps.discover.outputs.charts_json }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE_BUMP: ${{ github.event.inputs.force_bump || 'false' }}
+          CHART_INPUT: ${{ github.event.inputs.chart || '' }}
         run: |
           charts=$(echo "$CHARTS_JSON" | jq -r '.[]')
 
@@ -164,6 +172,11 @@ jobs:
             fi
 
             # Calculate next version
+            # Apply force_bump if auto_bump is none and force was requested
+            if [ "$auto_bump" = "none" ] && [ "${FORCE_BUMP}" = "true" ] && [ -n "${CHART_INPUT}" ]; then
+              auto_bump="patch"
+              echo "::notice::Forcing patch bump for ${chart}"
+            fi
             final_bump="${override:-$auto_bump}"
             if [ "$final_bump" = "none" ]; then
               echo "::warning::No bump needed for ${chart}, skipping"

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -39,6 +39,12 @@ jobs:
       - name: Load version pins
         uses: ./.github/actions/load-pins
 
+      - name: Validate inputs
+        if: ${{ github.event.inputs.force_bump == 'true' && github.event.inputs.chart == '' }}
+        run: |
+          echo "::error::force_bump=true requires a specific chart to be specified"
+          exit 1
+
       - name: Install generators (pinned)
         uses: ./.github/actions/install-generators
 
@@ -73,7 +79,7 @@ jobs:
             # Skip if the last commit to THIS chart is a release prep commit
             # This prevents re-triggering immediately after a release PR is merged
             last_commit_for_chart=$(git log -1 --pretty=%s -- "charts/${chart}/")
-            if echo "$last_commit_for_chart" | grep -q "^chore(${chart}): prepare release"; then
+            if [[ "$last_commit_for_chart" == "chore(${chart}): prepare release"* ]]; then
               echo "⏭️  ${chart}: last commit is a release prep, skipping"
               echo "::endgroup::"
               continue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,11 @@ If you're new to GitHub collaboration, see [GitHub's guide on forking and pull r
 4. Test locally (see [Testing & Validation](#testing--validation) section below)
 5. Commit with DCO sign-off: `git commit -s -m "fix(acapy): resolve health probe timeout"`
    - The `-s` flag is required for Linux Foundation projects ([DCO](https://developercertificate.org/))
-   - Use Conventional Commits format: `feat:`, `fix:`, `docs:`, `chore:`
+   - Use Conventional Commits format with version bump semantics:
+     - `feat:` → minor bump (new features)
+     - `fix:`, `perf:`, `refactor:` → patch bump
+     - `chore(deps):` → patch bump (for dependency/image updates)
+     - `chore:`, `docs:` → no release (internal maintenance)
    - Scope is optional in commits, but include the chart name in PR titles: `feat(acapy): add health probe`
 6. Open a Pull Request from your fork to `main`
    - Provide a clear description of what changed and why
@@ -64,6 +68,8 @@ If you're new to GitHub collaboration, see [GitHub's guide on forking and pull r
 After a feature PR merges, the Release-PR workflow runs (2 AM UTC or on push to main) and opens a Release PR with bumped version and generated changelog.
 
 **To defer release:** Add `skip-release` label to the Release PR (not the feature PR). More changes can accumulate. When ready, remove the label or close the PR to create a new one with all accumulated commits.
+
+**To force a release:** When only `chore:` or `docs:` commits exist but a release is still needed (e.g., image updates without `chore(deps):` scope), use the manual workflow trigger with `force_bump=true` and specify the chart name. This forces a patch release even when no releasable commits are detected.
 
 **To release immediately:** Review and merge the Release PR. Publishing triggers automatically.
 </details>

--- a/hack/release/classify_commits.sh
+++ b/hack/release/classify_commits.sh
@@ -40,12 +40,28 @@ docs_msgs=()
 other_msgs=()
 
 while IFS=$'\t' read -r sha subject body; do
-  # Extract type and full scope for more granular matching
-  type_scope=$(echo "${subject}" | sed -E 's/^(feat|fix|perf|refactor|chore|docs)(\([^)]*\))?!.*/\1!/' | sed -E 's/^(feat|fix|perf|refactor|chore|docs)(\([^)]*\))?:.*/\1/')
-  full_scope=$(echo "${subject}" | sed -E 's/^(feat|fix|perf|refactor|chore|docs)\(([^)]*)\).*/\2/' | sed -E 's/^(feat|fix|perf|refactor|chore|docs):.*//')
+  # Extract type and full scope for more granular matching.
+  # Only treat headers matching type(scope)!?: as having a scope; otherwise scope is empty.
+  type_scope=""
+  full_scope=""
+  # Store regex in variable to satisfy shellcheck
+  commit_regex='^(feat|fix|perf|refactor|chore|docs)(\([^)]*\))?(!)?: '
+  if [[ "${subject}" =~ ${commit_regex} ]]; then
+    type="${BASH_REMATCH[1]}"
+    scope_with_parens="${BASH_REMATCH[2]}"
+    bang="${BASH_REMATCH[3]}"
+    type_scope="${type}"
+    if [[ -n "${bang}" ]]; then
+      type_scope+="!"
+    fi
+    if [[ -n "${scope_with_parens}" ]]; then
+      # Strip surrounding parentheses from the captured scope.
+      full_scope="${scope_with_parens:1:${#scope_with_parens}-2}"
+    fi
+  fi
   breaking=false
-  if echo "${subject}" | grep -q '!:'; then breaking=true; fi
-  if echo "${body}" | grep -q 'BREAKING CHANGE:'; then breaking=true; fi
+  if printf '%s\n' "${subject}" | grep -q '!:'; then breaking=true; fi
+  if printf '%s\n' "${body}" | grep -q 'BREAKING CHANGE:'; then breaking=true; fi
   msg="- ${subject} (${sha:0:7})"
   case "${type_scope}" in
     feat*)


### PR DESCRIPTION
## Summary
Fixed the release-pr workflow to handle multiple charts independently, added `chore(deps)`: support for dependency/image updates.

## Details

#### Release Workflow Fixes (`.github/workflows/release-pr.yaml`)
- Per-chart skip logic - Replaced global "skip if last commit is release prep" check with per-chart check
    - Previously: If ANY chart's release PR was merged, ALL charts were blocked
    - Now: Only the specific chart whose last commit is a release prep is skipped
    - Other charts with unreleased changes still get release PRs
-  Added `force_bump` input - Allows forcing a patch release 
    - Requires `chart` input to be specified
    - Useful for edge cases where a release is needed but commits don't trigger one
    
#### Commit Classification (`hack/release/classify_commits.sh`)
- Added `chore(deps):` support - Dependency/image updates now trigger patch releases
    - `chore(deps): update image` → patch bump
    - `chore: internal change` → no release (unchanged)

#### Other updates
- Updated `CONTRIBUTING.md`