### PR TITLE
chore(acapy): update acapy-agent image to use py3.13-1.5.1

### DIFF
--- a/charts/acapy/Chart.yaml
+++ b/charts/acapy/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
     url: https://github.com/i5okie
 
 version: 1.0.0
-appVersion: "1.4.0"
+appVersion: "1.5.1"
 
 dependencies:
   - name: postgres

--- a/charts/acapy/README.md
+++ b/charts/acapy/README.md
@@ -1,6 +1,6 @@
 # AcaPy
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
 
 A Helm chart to deploy A Cloud Agent - Python.
 

--- a/charts/acapy/values.yaml
+++ b/charts/acapy/values.yaml
@@ -74,7 +74,7 @@ updateStrategy:
 image:
   registry: ghcr.io
   repository: openwallet-foundation/acapy-agent
-  tag: py3.12-1.4.0
+  tag: py3.13-1.5.1
   ## For production, prefer setting image.digest to an immutable sha256:... to guarantee supply chain integrity over mutable tags.
   digest: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- Update acapy-agent image tag to use the latest `1.5.1` release



## Release notes

- Update acapy-agent image tag to use the latest `1.5.1` release
