### PR TITLE
feat(endorser-service): Update to latest acapy-1.0.2 chart, implement new webhook setting, fix network policy

### DIFF
--- a/charts/endorser-service/Chart.lock
+++ b/charts/endorser-service/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: acapy
   repository: https://openwallet-foundation.github.io/helm-charts/
-  version: 1.0.0
+  version: 1.0.2
 - name: postgres
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.15.5
-digest: sha256:ee8a4e349cc95a50f9bf2d59a389c681ed88b4625305554abc4c0d9c5c0fe705
-generated: "2026-02-11T15:10:21.541621-08:00"
+digest: sha256:4091e70804eba48b19f49b2bab43c0f15d44c89115330690cac7903348dbbaa3
+generated: "2026-04-22T18:24:45.010748-07:00"

--- a/charts/endorser-service/Chart.yaml
+++ b/charts/endorser-service/Chart.yaml
@@ -14,7 +14,7 @@ maintainers:
     url: https://github.com/i5okie
 dependencies:
   - name: acapy
-    version: "1.0.0"
+    version: "1.0.2"
     repository: "https://openwallet-foundation.github.io/helm-charts/"
     condition: acapy.enabled
   - name: postgres

--- a/charts/endorser-service/README.md
+++ b/charts/endorser-service/README.md
@@ -1,6 +1,6 @@
 # endorser-service
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 A Helm chart for ACA-Py Endorser Service
 
 ## Prerequisites
@@ -166,7 +166,7 @@ This chart deploys an endorser service with the following components:
 | networkPolicy.proxy.allowExternalEgress | bool | `true` | Allow proxy pods to access any port and any destination. Set to false to restrict egress to DNS by default and layer additional rules via extraEgress. |
 | networkPolicy.proxy.extraEgress | list | `[]` | Additional egress rules for proxy pods |
 | networkPolicy.proxy.extraIngress | list | `[]` | Additional ingress rules for proxy pods Use this to add additional ingress sources beyond the ingress controller selectors. |
-| networkPolicy.proxy.ingress.namespaceSelector | object | `{}` | Namespace selector labels allowed to reach proxy pods. When both selectors are empty, ingress is allowed from any source on the proxy ports. OpenShift SDN:  network.openshift.io/policy-group: ingress OpenShift OVN:  kubernetes.io/metadata.name: openshift-ingress |
+| networkPolicy.proxy.ingress.namespaceSelector | object | `{}` | Namespace selector labels allowed to reach proxy pods. When both selectors are empty, ingress is allowed from any source on the proxy ports. Example (ingress-nginx): kubernetes.io/metadata.name: ingress-nginx |
 | networkPolicy.proxy.ingress.podSelector | object | `{}` | Pod selector labels allowed to reach proxy pods inside matching namespaces |
 | nodeSelector | object | `{}` | Node selector for API pods |
 | podAnnotations | object | `{}` | Annotations to add to API pods |
@@ -193,7 +193,7 @@ This chart deploys an endorser service with the following components:
 | postgres.podSecurityContext.fsGroup | int | `999` | Group ID for the pod's volumes |
 | postgres.resources | object | `{}` | Resource requests and limits for PostgreSQL |
 | postgres.service.port | int | `5432` | PostgreSQL service port |
-| postgres.targetPlatform | string | `""` | Target platform for deployment. Set to "openshift" for OpenShift compatibility (auto-detected if not set) |
+| postgres.targetPlatform | string | `""` | Target platform for deployment (e.g., "openshift"). Adjusts security context defaults for the target environment. Auto-detected if not set. |
 | proxy.affinity | object | `{}` | Affinity rules for proxy pods |
 | proxy.autoscaling.enabled | bool | `false` | Enable autoscaling |
 | proxy.autoscaling.maxReplicas | int | `9` | Maximum replicas |
@@ -210,7 +210,7 @@ This chart deploys an endorser service with the following components:
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | proxy.image.repository | string | `"ghcr.io/i5okie/caddy-rootless"` | Image repository |
 | proxy.image.tag | string | `"2-alpine"` | Image tag |
-| proxy.ingress.annotations | object | `{"route.openshift.io/termination":"edge"}` | Ingress annotations |
+| proxy.ingress.annotations | object | `{}` | Ingress annotations |
 | proxy.ingress.className | string | `""` | Ingress class name |
 | proxy.ingress.enabled | bool | `true` | Enable ingress for proxy |
 | proxy.ingress.hosts[0].host | string | `"endorser-agent.example.com"` |  |

--- a/charts/endorser-service/README.md
+++ b/charts/endorser-service/README.md
@@ -1,6 +1,6 @@
 # endorser-service
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 A Helm chart for ACA-Py Endorser Service
 
 ## Prerequisites
@@ -60,7 +60,7 @@ This chart deploys an endorser service with the following components:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://openwallet-foundation.github.io/helm-charts/ | acapy | 1.0.0 |
+| https://openwallet-foundation.github.io/helm-charts/ | acapy | 1.0.2 |
 | oci://registry-1.docker.io/cloudpirates | postgres | 0.15.5 |
 
 ## Parameters
@@ -85,7 +85,6 @@ This chart deploys an endorser service with the following components:
 | acapy.agentUrl | string | `"https://endorser-agent.example.com"` | External agent URL (public endpoint) |
 | acapy.enabled | bool | `true` | Enable ACA-Py agent deployment |
 | acapy.extraEnvVars | list | `[]` | Extra environment variables as an array |
-| acapy.extraEnvVarsSecret | string | `"{{ printf \"%s-acapy-webhook\" .Release.Name | trunc 63 | trimSuffix \"-\" }}"` | Name of existing secret containing extra environment variables (webhook URL for endorser) Template is evaluated by common.tplvalues.render in Aca-Py deployment |
 | acapy.image.registry | string | `"ghcr.io"` | Container image registry |
 | acapy.image.repository | string | `"openwallet-foundation/acapy-endorser-service/agent"` | Container image repository |
 | acapy.image.tag | string | `"1.1.2"` | Image tag (defaults to ACA-Py's chart appVersion) |
@@ -102,6 +101,8 @@ This chart deploys an endorser service with the following components:
 | acapy.service.ports.admin | int | `8051` | Admin API port |
 | acapy.service.ports.http | int | `8050` | HTTP port for agent endpoints |
 | acapy.service.ports.ws | int | `8052` | WebSocket port |
+| acapy.webhook.existingSecret | string | `"{{ printf \"%s-acapy-webhook\" .Release.Name | trunc 63 | trimSuffix \"-\" }}"` | Name of the Secret containing a pre-composed ACAPY_WEBHOOK_URL (with embedded API key). Evaluated as a template; takes precedence over webhook.url. Points to the chart-managed webhook secret by default. |
+| acapy.webhook.secretKey | string | `"ACAPY_WEBHOOK_URL"` | Key within the secret that holds the full webhook URL value. |
 | acapy.websockets.enabled | bool | `true` | Enable WebSocket support |
 | affinity | object | `{}` | Affinity rules for API pods |
 | api.acapyAdminUrl | string | `"https://endorser-agent-admin.example.com"` | ACA-Py admin URL (external) |

--- a/charts/endorser-service/README.md
+++ b/charts/endorser-service/README.md
@@ -165,8 +165,7 @@ This chart deploys an endorser service with the following components:
 | networkPolicy.proxy.allowExternalEgress | bool | `true` | Allow proxy pods to access any port and any destination. Set to false to restrict egress to DNS by default and layer additional rules via extraEgress. |
 | networkPolicy.proxy.extraEgress | list | `[]` | Additional egress rules for proxy pods |
 | networkPolicy.proxy.extraIngress | list | `[]` | Additional ingress rules for proxy pods Use this to add additional ingress sources beyond the ingress controller selectors. |
-| networkPolicy.proxy.ingress.enabled | bool | `true` | Enable selector-based ingress rules for proxy pods |
-| networkPolicy.proxy.ingress.namespaceSelector | object | `{}` | Namespace selector labels allowed to reach proxy pods When both selectors are empty, ingress is allowed from any source on the proxy ports. |
+| networkPolicy.proxy.ingress.namespaceSelector | object | `{}` | Namespace selector labels allowed to reach proxy pods. When both selectors are empty, ingress is allowed from any source on the proxy ports. OpenShift SDN:  network.openshift.io/policy-group: ingress OpenShift OVN:  kubernetes.io/metadata.name: openshift-ingress |
 | networkPolicy.proxy.ingress.podSelector | object | `{}` | Pod selector labels allowed to reach proxy pods inside matching namespaces |
 | nodeSelector | object | `{}` | Node selector for API pods |
 | podAnnotations | object | `{}` | Annotations to add to API pods |

--- a/charts/endorser-service/templates/proxy/networkpolicy.yaml
+++ b/charts/endorser-service/templates/proxy/networkpolicy.yaml
@@ -26,13 +26,20 @@ spec:
   ingress:
     {{- if or $proxyIngressNamespaceSelector $proxyIngressPodSelector }}
     - from:
-        - {{ if $proxyIngressNamespaceSelector }}namespaceSelector:
+        {{- if $proxyIngressNamespaceSelector }}
+        - namespaceSelector:
             matchLabels:
               {{- toYaml $proxyIngressNamespaceSelector | nindent 14 }}
-          {{ end }}{{- if $proxyIngressPodSelector }}podSelector:
+          {{- if $proxyIngressPodSelector }}
+          podSelector:
             matchLabels:
               {{- toYaml $proxyIngressPodSelector | nindent 14 }}
-          {{ end }}
+          {{- end }}
+        {{- else if $proxyIngressPodSelector }}
+        - podSelector:
+            matchLabels:
+              {{- toYaml $proxyIngressPodSelector | nindent 14 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.proxy.service.ports.agent }}

--- a/charts/endorser-service/templates/proxy/networkpolicy.yaml
+++ b/charts/endorser-service/templates/proxy/networkpolicy.yaml
@@ -24,19 +24,15 @@ spec:
     - Ingress
     - Egress
   ingress:
-    {{- if and .Values.proxy.ingress.enabled .Values.networkPolicy.proxy.ingress.enabled }}
     {{- if or $proxyIngressNamespaceSelector $proxyIngressPodSelector }}
     - from:
-        - {{- if $proxyIngressNamespaceSelector }}
-          namespaceSelector:
+        - {{ if $proxyIngressNamespaceSelector }}namespaceSelector:
             matchLabels:
               {{- toYaml $proxyIngressNamespaceSelector | nindent 14 }}
-          {{- end }}
-          {{- if $proxyIngressPodSelector }}
-          podSelector:
+          {{ end }}{{- if $proxyIngressPodSelector }}podSelector:
             matchLabels:
               {{- toYaml $proxyIngressPodSelector | nindent 14 }}
-          {{- end }}
+          {{ end }}
       ports:
         - protocol: TCP
           port: {{ .Values.proxy.service.ports.agent }}
@@ -52,7 +48,6 @@ spec:
           port: {{ .Values.proxy.service.ports.admin }}
         - protocol: TCP
           port: {{ .Values.proxy.service.ports.endorser }}
-    {{- end }}
     {{- end }}
     {{- with .Values.networkPolicy.proxy.extraIngress }}
     {{- toYaml . | nindent 4 }}

--- a/charts/endorser-service/values.yaml
+++ b/charts/endorser-service/values.yaml
@@ -178,14 +178,15 @@ networkPolicy:
     extraIngress: []
   # Proxy component network policy settings
   proxy:
-    # Selector-based ingress control for proxy pods
+    # Selector-based ingress control for proxy pods.
+    # This is independent of whether a Kubernetes Ingress resource is deployed (proxy.ingress.enabled).
+    # It controls which sources (e.g. ingress controller) are allowed to reach the proxy.
     ingress:
-      # -- Enable selector-based ingress rules for proxy pods
-      enabled: true
-      # -- Namespace selector labels allowed to reach proxy pods
+      # -- Namespace selector labels allowed to reach proxy pods.
       # When both selectors are empty, ingress is allowed from any source on the proxy ports.
+      # OpenShift SDN:  network.openshift.io/policy-group: ingress
+      # OpenShift OVN:  kubernetes.io/metadata.name: openshift-ingress
       namespaceSelector: {}
-        # network.openshift.io/policy-group: ingress
       # -- Pod selector labels allowed to reach proxy pods inside matching namespaces
       podSelector: {}
     # -- Allow proxy pods to access any port and any destination.

--- a/charts/endorser-service/values.yaml
+++ b/charts/endorser-service/values.yaml
@@ -184,8 +184,7 @@ networkPolicy:
     ingress:
       # -- Namespace selector labels allowed to reach proxy pods.
       # When both selectors are empty, ingress is allowed from any source on the proxy ports.
-      # OpenShift SDN:  network.openshift.io/policy-group: ingress
-      # OpenShift OVN:  kubernetes.io/metadata.name: openshift-ingress
+      # Example (ingress-nginx): kubernetes.io/metadata.name: ingress-nginx
       namespaceSelector: {}
       # -- Pod selector labels allowed to reach proxy pods inside matching namespaces
       podSelector: {}
@@ -390,7 +389,7 @@ acapy:
 postgres:
   # -- Switch to enable or disable the Postgres helm chart
   enabled: true
-  # -- Target platform for deployment. Set to "openshift" for OpenShift compatibility (auto-detected if not set)
+  # -- Target platform for deployment (e.g., "openshift"). Adjusts security context defaults for the target environment. Auto-detected if not set.
   targetPlatform: ""
   # Postgres container image
   image:
@@ -435,12 +434,12 @@ postgres:
     # -- PVC Storage Request for PostgreSQL volume
     size: 1Gi
   # Pod Security Context
-  # Note: When targetPlatform is "openshift", these are automatically omitted
+  # Note: These fields may be omitted automatically depending on the targetPlatform value
   podSecurityContext:
     # -- Group ID for the pod's volumes
     fsGroup: 999
   # Container Security Context
-  # Note: When targetPlatform is "openshift", runAsUser/runAsGroup are automatically omitted
+  # Note: runAsUser/runAsGroup may be omitted automatically depending on the targetPlatform value
   containerSecurityContext:
     # -- User ID for the container
     runAsUser: 999
@@ -526,8 +525,8 @@ proxy:
     # -- Ingress class name
     className: ""
     # -- Ingress annotations
-    annotations:
-      route.openshift.io/termination: edge
+    annotations: {}
+      # nginx.ingress.kubernetes.io/ssl-redirect: "true"
     # Ingress hosts (typically three: agent, admin, endorser)
     hosts:
       - host: endorser-agent.example.com

--- a/charts/endorser-service/values.yaml
+++ b/charts/endorser-service/values.yaml
@@ -324,9 +324,14 @@ acapy:
       witness: true
   # -- Extra environment variables as an array
   extraEnvVars: []
-  # -- Name of existing secret containing extra environment variables (webhook URL for endorser)
-  # Template is evaluated by common.tplvalues.render in Aca-Py deployment
-  extraEnvVarsSecret: '{{ printf "%s-acapy-webhook" .Release.Name | trunc 63 | trimSuffix "-" }}'
+  # Webhook configuration for ACA-Py to deliver events to the endorser API
+  webhook:
+    # -- Name of the Secret containing a pre-composed ACAPY_WEBHOOK_URL (with embedded API key).
+    # Evaluated as a template; takes precedence over webhook.url.
+    # Points to the chart-managed webhook secret by default.
+    existingSecret: '{{ printf "%s-acapy-webhook" .Release.Name | trunc 63 | trimSuffix "-" }}'
+    # -- Key within the secret that holds the full webhook URL value.
+    secretKey: ACAPY_WEBHOOK_URL
   # -- External agent URL (public endpoint)
   agentUrl: https://endorser-agent.example.com
   # -- External admin URL (public endpoint)


### PR DESCRIPTION
## Summary

This PR addresses `webhook-url` setting issues by updating to the latest `acapy` chart. The updated chart allows specifying `webhook-url` via an existing secret without a confusing default `webhook-url` in argfile. The PR also fixes the proxy network policy bug where ingress was being set to null rendering proxy service unreachable.

## Details

- Bump `acapy` chart dependency to latest 1.0.2
- Use acapy chart's updated `webhook.url` setting instead of `extraEnvVarsSecret`
- Fix network policy rendering
- Remove openshift defaults from values and update documentation