### PR TITLE
chore(acapy): bump acapy-agent version to py3.13-1.6.0

### DIFF
--- a/charts/acapy/Chart.yaml
+++ b/charts/acapy/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
     url: https://github.com/i5okie
 
 version: 1.0.2
-appVersion: "1.5.1"
+appVersion: "1.6.0"
 
 dependencies:
   - name: postgres

--- a/charts/acapy/values.yaml
+++ b/charts/acapy/values.yaml
@@ -74,7 +74,7 @@ updateStrategy:
 image:
   registry: ghcr.io
   repository: openwallet-foundation/acapy-agent
-  tag: py3.13-1.5.1
+  tag: py3.13-1.6.0
   ## For production, prefer setting image.digest to an immutable sha256:... to guarantee supply chain integrity over mutable tags.
   digest: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

Bump `acapy-agent` version to `py3.13-1.6.0`  ( [ACA-Py Release 1.6.0](https://github.com/openwallet-foundation/acapy/releases/tag/1.6.0) )